### PR TITLE
[fix](detailPost): 이미지 미출력 이슈

### DIFF
--- a/components/templates/DetailPostTemplate.tsx
+++ b/components/templates/DetailPostTemplate.tsx
@@ -2,7 +2,6 @@ import { Icon, Span, Title } from '@/components/atoms';
 import useCalcRegisterDate from '@/hooks/useCalcRegisterDate';
 import { COLOR } from '@/styles/color';
 import { Layout } from '@/styles/theme';
-import Image from 'next/image';
 import router from 'next/router';
 import React from 'react';
 import styled from 'styled-components';
@@ -123,12 +122,10 @@ const DetailPostTemplate = (): JSX.Element => {
       </TitleSection>
       <ImageSection>
         {post.thumbnail && (
-          <Image
+          <img
             src={'https://picsum.photos/360/306'}
             alt={'contentImage'}
-            width={'100%'}
-            height={'306px'}
-            objectFit={'cover'}
+            style={{ width: '100%', height: '306px', objectFit: 'cover' }}
           />
         )}
       </ImageSection>


### PR DESCRIPTION
## What?

- 피드 상세 페이지 이미지가 출력되지 않았습니다.

## Why?

- remote 이미지의 경우 next.config.js에 도메인 주소를 추가해야 하는지 몰랐습니다.
  - [해당 도큐먼트 링크](https://nextjs.org/docs/basic-features/image-optimization#domains)

## How?

- 외부 링크에서 사용하는 이미지가 존재하지 않는다는 판단 하였습니다
  - next.config.js 미수정
  - next/image -> img 태그로 변경