### PR TITLE
[feat] app permission 관련 feature 추가

### DIFF
--- a/components/atoms/Icon/Camera.tsx
+++ b/components/atoms/Icon/Camera.tsx
@@ -1,0 +1,17 @@
+import React, { memo } from 'react';
+import { SVGIconProps } from './';
+
+const CameraIcon = (({ fill = '#8478EF', height = '24px', onClick, style }: SVGIconProps) => (
+  <svg
+    height={height}
+    viewBox="0 0 24 24"
+    fill='none'
+    style={style}
+    onClick={onClick ? onClick : () => {
+    }}
+  >
+    <path fillRule="evenodd" clipRule="evenodd" d="M10.5352 4C9.86648 4 9.24201 4.3342 8.87108 4.8906L7.46482 7H5C3.89543 7 3 7.89543 3 9V18C3 19.1046 3.89543 20 5 20H19C20.1046 20 21 19.1046 21 18V9C21 7.89543 20.1046 7 19 7H16.5352L15.1289 4.8906C14.758 4.3342 14.1335 4 13.4648 4H10.5352ZM10.5352 6H13.4648L14.8711 8.1094C15.242 8.6658 15.8665 9 16.5352 9H19V18H5V9H7.46482C8.13352 9 8.75799 8.6658 9.12892 8.1094L10.5352 6ZM14 13C14 14.1046 13.1046 15 12 15C10.8954 15 10 14.1046 10 13C10 11.8954 10.8954 11 12 11C13.1046 11 14 11.8954 14 13ZM16 13C16 15.2091 14.2091 17 12 17C9.79086 17 8 15.2091 8 13C8 10.7909 9.79086 9 12 9C14.2091 9 16 10.7909 16 13Z" fill={fill}/>
+  </svg>
+));
+
+export default memo(CameraIcon);

--- a/components/atoms/Icon/Folder.tsx
+++ b/components/atoms/Icon/Folder.tsx
@@ -1,0 +1,17 @@
+import React, { memo } from 'react';
+import { SVGIconProps } from './';
+
+const FolderIcon = (({ fill = '#8478EF', height = '24px', onClick, style }: SVGIconProps) => (
+  <svg
+    height={height}
+    viewBox="0 0 24 24"
+    fill='none'
+    style={style}
+    onClick={onClick ? onClick : () => {
+    }}
+  >
+    <path d="M11.2929 6.70711L11.5858 7H12H20V19H4L4 5H9.58579L11.2929 6.70711Z" stroke={fill} strokeWidth="2"/>
+  </svg>
+));
+
+export default memo(FolderIcon);

--- a/components/atoms/Icon/index.ts
+++ b/components/atoms/Icon/index.ts
@@ -24,3 +24,5 @@ export { default as ArrowDown } from './ArrowDown';
 export { default as Back } from './Back';
 export { default as GomingOut } from './GomingOut';
 export { default as Bell } from './Bell';
+export { default as Camera } from './Camera';
+export { default as Folder } from './Folder';

--- a/components/atoms/Title.tsx
+++ b/components/atoms/Title.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 const Title = styled.p`
-  font-weight: 400;
+  font-weight: 700;
   line-height: 1.27;
   color: ${({ theme }) => theme.BLACK};
   margin: 0;

--- a/components/molcules/Popup.tsx
+++ b/components/molcules/Popup.tsx
@@ -62,17 +62,16 @@ const PopupHeaderTitle = styled.p`
 const PopupContents = styled.section`
   ${Layout.flexColCenter};
   position: absolute;
+  box-shadow: 0px 0px 8px rgba(0, 0, 0, 0.15);
   top: 50%;
   left: 50%;
 
   max-width: 480px;
-  width: calc(100% - 88px);
+  width: calc(100% - 40px);
 
   paddingTop: 16px;
-  border-radius: 8px;
 
   background: ${({ theme }) => theme.WHITE};
-  box-shadow: 0 0 14px 3px rgba(34, 34, 34, 0.1);
   transform: translate(-50%, -50%);
   overflow: hidden;
 `;
@@ -80,7 +79,8 @@ const PopupContents = styled.section`
 const PopupOverLay = styled.section`
   width: 100%;
   height: 100%;
-  background-color: rgba(34, 34, 34, 0.5);
+  background: rgba(255, 255, 255, 0.3);
+  backdrop-filter: blur(3px);
 `;
 
 const PopupBtnContainer = styled.section`
@@ -95,8 +95,10 @@ const PopupBtnContainer = styled.section`
 
 const Button = styled.button`
   border: none;
-  padding: 12px 0;
+  padding: 20px 0;
   background-color: ${({ theme }) => theme.WHITE};
+  color: ${({ theme }) => theme.GRAY07};
+  font-size: 15px;
 `;
 
 const PopupFooter = (
@@ -172,7 +174,7 @@ export default function DefaultPopup(
       {useOverlay && <PopupOverLay/>}
       <PopupContents style={contentsStyle}>
         <PopupHeader style={headerStyle}>
-          <PopupHeaderTitle dangerouslySetInnerHTML={{ __html: title }}/>
+          {title && <PopupHeaderTitle dangerouslySetInnerHTML={{ __html: title }}/>}
           {useClose &&
           <Icon.Close
             style={{
@@ -184,7 +186,7 @@ export default function DefaultPopup(
             onClick={failCallback}
           />}
         </PopupHeader>
-        <section style={mainStyle}>{children}</section>
+        <section style={{ width: '100%', ...mainStyle }}>{children}</section>
 
         {PopupFooter({ type, successTitle, successCallback, failTitle, failCallback, successDisable, failDisable })}
       </PopupContents>

--- a/components/organisms/common/ATTPermissionRequestPopup.tsx
+++ b/components/organisms/common/ATTPermissionRequestPopup.tsx
@@ -1,0 +1,38 @@
+import styled from 'styled-components';
+
+import { Span, Title } from '@/components/atoms';
+import { Popup } from '@/components/molcules';
+import { COLOR, Layout } from '@/styles/index';
+import { requestPermission } from '@/hooks/index';
+
+const ATTPermissionContainer = styled.section`
+  ${Layout.flexColCenterStart};
+  width: 100%;
+  padding: 20px 20px 10px;
+  box-sizing: border-box;
+`;
+
+export default function ATTPermissionRequestPopup({ closeDispatch }: { closeDispatch(): void; }) {
+  return (
+    <Popup
+      useClose={false}
+      type={'ONE'}
+      successTitle={'확인'}
+      successCallback={() => {
+        closeDispatch && closeDispatch();
+        requestPermission({ permissionType: 'ATT' });
+      }}
+    >
+      <ATTPermissionContainer>
+        <Title style={{ fontSize: '24px', marginBottom: '10px' }}>
+          {'추적 허용 필요'}
+        </Title>
+        <Span style={{ color: COLOR.GRAY05 }}>
+          {'최적화된 광고 제공을 위해 추적 허용이 필요합니다.'}<br/>
+          {'소중한 정보는 애플 정책을 기반으로'}<br/>
+          {'광고 제공을 위해서만 사용됩니다.'}
+        </Span>
+      </ATTPermissionContainer>
+    </Popup>
+  );
+}

--- a/components/organisms/common/PhotoPermissionBlockedPopup.tsx
+++ b/components/organisms/common/PhotoPermissionBlockedPopup.tsx
@@ -1,0 +1,40 @@
+import styled from 'styled-components';
+
+import { Span, Title } from '@/components/atoms';
+import { Popup } from '@/components/molcules';
+import { COLOR, Layout } from '@/styles/index';
+import { moveToOption } from '@/hooks/index';
+
+const PhotoPermissionContainer = styled.section`
+  ${Layout.flexColCenterStart};
+  width: 100%;
+  padding: 20px 20px 10px;
+  box-sizing: border-box;
+`;
+
+export default function PhotoPermissionBlockedPopup({ closeDispatch }: { closeDispatch(): void; }) {
+  return (
+    <Popup
+      useClose={false}
+      type={'TWO'}
+      successTitle={'설정하러 가기'}
+      successCallback={() => {
+        moveToOption();
+      }}
+      failTitle={'닫기'}
+      failCallback={() => {
+        closeDispatch && closeDispatch();
+      }}
+    >
+      <PhotoPermissionContainer>
+        <Title style={{ fontSize: '24px', marginBottom: '10px' }}>
+          {'권한 허용 필요'}
+        </Title>
+        <Span style={{ color: COLOR.GRAY05 }}>
+          {'카메라와 저장공간에 대한 사용을 거부하였습니다.'}<br/>
+          {'기능 사용을 원하실 경우 휴대폰 설정>애플리케이션 관리자에서 권한을 허용해주세요.'}
+        </Span>
+      </PhotoPermissionContainer>
+    </Popup>
+  );
+}

--- a/components/organisms/common/PhotoPermissionRequestPopup.tsx
+++ b/components/organisms/common/PhotoPermissionRequestPopup.tsx
@@ -1,0 +1,73 @@
+import styled from 'styled-components';
+
+import { Span, Title, Icon } from '@/components/atoms';
+import { Popup } from '@/components/molcules';
+import { COLOR, Layout } from '@/styles/index';
+import { requestMultiPermission } from '@/hooks/index';
+
+const PhotoPermissionContainer = styled.section`
+  ${Layout.flexColStartCenter};
+  width: 100%;
+  padding: 20px;
+  box-sizing: border-box;
+`;
+
+const PhotoPermissionHeader = styled.div`
+  ${Layout.flexColStartStart};
+  width: 100%;
+  border-bottom: ${({ theme }) => `1px solid ${theme.GRAY03}`}
+`;
+
+const PhotoPermissionContent = styled.div`
+  ${Layout.flexColStartStart};
+  width: 100%;
+  margin-top: 21px;
+`;
+
+const PermissionTypeBox = styled.div`
+  ${Layout.flexRowStartCenter};
+  width: 100%;
+`;
+
+export default function PhotoPermissionRequestPopup({ closeDispatch }: { closeDispatch(): void; }) {
+  return (
+    <Popup
+      useClose={false}
+      type={'TWO'}
+      successTitle={'허용'}
+      successCallback={() => {
+        requestMultiPermission({ permissionTypeList: ['CAMERA', 'PHOTO']});
+      }}
+      failTitle={'거부'}
+      failCallback={() => {
+        closeDispatch && closeDispatch();
+      }}
+    >
+      <PhotoPermissionContainer>
+        <PhotoPermissionHeader>
+          <Title style={{ fontSize: '24px', marginBottom: '10px' }}>
+            {'고밍아웃 권한 안내'}
+          </Title>
+          <Span style={{ color: COLOR.GRAY05, marginBottom: '15px' }}>{'서비스 사용을 위해'}<br/>{'다음의 접근 권한이 필요합니다.'}</Span>
+        </PhotoPermissionHeader>
+        <PhotoPermissionContent>
+          <PermissionTypeBox>
+            <Icon.Camera style={{ marginRight: '7px', marginBottom: '2px' }}/>
+            <Span style={{ color: COLOR.GRAY07, fontWeight: 700, fontSize: '16px' }}>{'카메라 촬영과 사진'}</Span>
+          </PermissionTypeBox>
+          <Span style={{ color: COLOR.GRAY05, marginTop: '5px', marginBottom: '20px' }}>
+            {'사진 첨부를 위해 사진을 촬영하는 경우'}
+          </Span>
+
+          <PermissionTypeBox>
+            <Icon.Folder style={{ marginRight: '7px', marginBottom: '2px' }}/>
+            <Span style={{ color: COLOR.GRAY07, fontWeight: 700, fontSize: '16px' }}>{'저장공간'}</Span>
+          </PermissionTypeBox>
+          <Span style={{ color: COLOR.GRAY05, marginTop: '5px' }}>
+            {'사진 첨부를 위해 저장공간에 접근하는 경우'}
+          </Span>
+        </PhotoPermissionContent>
+      </PhotoPermissionContainer>
+    </Popup>
+  );
+}

--- a/components/organisms/common/index.ts
+++ b/components/organisms/common/index.ts
@@ -1,3 +1,4 @@
 export { default as BottomNav } from './BottomNav';
 export { default as PhotoPermissionRequestPopup } from './PhotoPermissionRequestPopup';
 export { default as PhotoPermissionBlockedPopup } from './PhotoPermissionBlockedPopup';
+export { default as ATTPermissionRequestPopup } from './ATTPermissionRequestPopup';

--- a/components/organisms/common/index.ts
+++ b/components/organisms/common/index.ts
@@ -1,1 +1,3 @@
 export { default as BottomNav } from './BottomNav';
+export { default as PhotoPermissionRequestPopup } from './PhotoPermissionRequestPopup';
+export { default as PhotoPermissionBlockedPopup } from './PhotoPermissionBlockedPopup';

--- a/components/organisms/community/PostItem.tsx
+++ b/components/organisms/community/PostItem.tsx
@@ -73,7 +73,7 @@ export default function PostItem({ post }: { post: any }): JSX.Element {
         <CategoryBox>{post.category}</CategoryBox>
         <ContentSection>
           <TextSection>
-            <Title style={{ marginBottom: '8px' }}>{post.title}</Title>
+            <Title style={{ marginBottom: '8px', fontWeight: 400 }}>{post.title}</Title>
             <ContentSpan>{post.content}</ContentSpan>
           </TextSection>
           {post.thumbnail && (

--- a/components/organisms/new/SelectCategory.tsx
+++ b/components/organisms/new/SelectCategory.tsx
@@ -51,7 +51,7 @@ export default function SelectCategory({ selectDispatch }: { selectDispatch: (v:
                 checked={checkedValue === item}
                 onChange={() => setCheckedValue(item)}
               />
-              <label style={{ color: COLOR.BLACK }} htmlFor={item} onClick={() => { selectDispatch(item); }}>
+              <label style={{ color: COLOR.BLACK, width: '100%' }} htmlFor={item} onClick={() => { selectDispatch(item); }}>
                 <CategoryItem>
                   <Span style={{ color: COLOR.BLACK }}>{CATEGORY_LIST[item]}</Span>
                 </CategoryItem>

--- a/components/templates/LoginTemplate.tsx
+++ b/components/templates/LoginTemplate.tsx
@@ -1,13 +1,17 @@
-import {useContext, useEffect, useState} from 'react';
+import { useContext, useEffect, useState } from 'react';
 import styled from 'styled-components';
+
 import { COLOR, Layout } from '@/styles/index';
+import { KAKAO_KEY } from '@/constants/index';
+
+import { checkPermission } from '@/hooks/index';
+import { AppAuthorContext } from '@/provider/index';
+import { isApp, isIphone } from '@/utils/index';
+
 import { Title, Span, Icon } from '@/components/atoms';
 import { Loading } from '@/components/molcules';
-import { KAKAO_KEY } from '@/constants/index';
 import { ATTPermissionRequestPopup } from '@/components/organisms';
-import {checkPermission} from "@/hooks/useAppProtocol";
-import {AppAuthorContext} from "@/provider/AppAuthor";
-import {isApp} from "@/utils/device";
+
 
 const MainContainer = styled.main`
   ${Layout.flexColStartCenter};
@@ -57,7 +61,7 @@ export default function LoginTemplate(): JSX.Element {
   const authData = useContext(AppAuthorContext);
 
   useEffect(() => {
-    if (isApp()) {
+    if (isApp() && isIphone()) {
       checkPermission({ permissionType: 'ATT' });
     }
 
@@ -84,7 +88,7 @@ export default function LoginTemplate(): JSX.Element {
 
   return (
     <MainContainer>
-      {showATTPermissionPopup && <ATTPermissionRequestPopup closeDispatch={() => setShowATTPermissionPopup(false)} />}
+      {showATTPermissionPopup && <ATTPermissionRequestPopup closeDispatch={() => setShowATTPermissionPopup(false)}/>}
       <TextArea>
         <Span style={{ fontSize: '16px', marginBottom: '6px' }}>{'슬펐던 일, 답답한 고민 모두'}</Span>
         <TitleDiv>
@@ -100,7 +104,13 @@ export default function LoginTemplate(): JSX.Element {
       <LoginButtonSection>
         <LoginButtonArea onClick={kakaoLogin}>
           <Icon.Kakao style={{ position: 'relative', left: '30px' }} height={'22px'}/>
-          <Span style={{ fontSize: '16px', display: 'block', width: '100%', textAlign: 'center', marginRight: '10px' }}>{'카카오로 로그인'}</Span>
+          <Span style={{
+            fontSize: '16px',
+            display: 'block',
+            width: '100%',
+            textAlign: 'center',
+            marginRight: '10px'
+          }}>{'카카오로 로그인'}</Span>
         </LoginButtonArea>
         <Span style={{ color: COLOR.GRAY05, fontSize: '12px', marginTop: '13px' }}>
           {'시작하면 '}

--- a/components/templates/NewPostTemplate.tsx
+++ b/components/templates/NewPostTemplate.tsx
@@ -115,11 +115,12 @@ export default function NewPostTemplate(): JSX.Element {
   useEffect(() => {
     if (isApp()) {
       const { CAMERA: cameraAuth, PHOTO: photoAuth } = authData;
-      if ((showPhotoPermissionRequestPopup || showPhotoPermissionBlockedPopup) && cameraAuth === 'granted' && photoAuth === 'granted') {
+      const authGranted = cameraAuth === 'granted' && photoAuth === 'granted';
+      if (showPhotoPermissionRequestPopup && authGranted) {
         setShowPhotoPermissionRequestPopup(false);
         inputRef.current && inputRef.current.click();
       }
-      if (showPhotoPermissionBlockedPopup && cameraAuth === 'granted' && photoAuth === 'granted' ) {
+      if (showPhotoPermissionBlockedPopup && authGranted) {
         setShowPhotoPermissionBlockedPopup(false);
       }
     }

--- a/components/templates/NewPostTemplate.tsx
+++ b/components/templates/NewPostTemplate.tsx
@@ -6,11 +6,12 @@ import { useForm } from 'react-hook-form';
 import { COLOR, Layout } from '@/styles/index';
 import { COLOR_TYPE } from '@/types/index';
 import { Span, Icon, Input, TextArea } from '@/components/atoms';
-import { SelectCategory } from '@/components/organisms';
+import { SelectCategory, PhotoPermissionRequestPopup } from '@/components/organisms';
 import { AppAuthorContext } from '@/provider/index';
 import { isApp, stackRouterBack } from '@/utils/index';
-import { checkPermission, moveToOption, requestMultiPermission } from '@/hooks/index';
+import { checkPermission } from '@/hooks/index';
 import { CATEGORY_LIST } from '@/constants/index';
+import PhotoPermissionBlockedPopup from '../organisms/common/PhotoPermissionBlockedPopup';
 
 const MainContainer = styled.main`
   ${Layout.flexColStartStart};
@@ -30,7 +31,7 @@ const HeaderSection = styled.section`
   height: 56px;
   padding: 0 17px 9px;
   box-sizing: border-box;
-  border-bottom: ${({ theme }) => `1px solid ${theme.GRAY02}`}
+  border-bottom: ${({ theme }) => `1px solid ${theme.GRAY02}`};
 `;
 
 const CategorySection = styled.section`
@@ -71,11 +72,18 @@ interface Image {
   filePath: string;
 }
 
+const checkPhotoPermission = () => {
+  checkPermission({ permissionType: 'CAMERA' });
+  checkPermission({ permissionType: 'PHOTO' });
+};
+
 export default function NewPostTemplate(): JSX.Element {
   const router = useRouter();
   const inputRef = useRef<HTMLInputElement>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [showCategory, setShowCategory] = useState<boolean>(false);
+  const [showPhotoPermissionRequestPopup, setShowPhotoPermissionRequestPopup] = useState<boolean>(false);
+  const [showPhotoPermissionBlockedPopup, setShowPhotoPermissionBlockedPopup] = useState<boolean>(false);
   const authData = useContext(AppAuthorContext);
 
   const methods = useForm<{ category: string; title: string; content: string; postImages: Array<Image> }>({
@@ -91,10 +99,31 @@ export default function NewPostTemplate(): JSX.Element {
 
   useEffect(() => {
     if (isApp()) {
-      checkPermission({ permissionType: 'CAMERA' });
-      checkPermission({ permissionType: 'PHOTO' });
+      document.addEventListener('visibilitychange', checkPhotoPermission);
+    }
+    return () => {
+      isApp() && document.removeEventListener('visibilitychange', checkPhotoPermission);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (isApp()) {
+      checkPhotoPermission();
     }
   }, [watchImages]);
+
+  useEffect(() => {
+    if (isApp()) {
+      const { CAMERA: cameraAuth, PHOTO: photoAuth } = authData;
+      if ((showPhotoPermissionRequestPopup || showPhotoPermissionBlockedPopup) && cameraAuth === 'granted' && photoAuth === 'granted') {
+        setShowPhotoPermissionRequestPopup(false);
+        inputRef.current && inputRef.current.click();
+      }
+      if (showPhotoPermissionBlockedPopup && cameraAuth === 'granted' && photoAuth === 'granted' ) {
+        setShowPhotoPermissionBlockedPopup(false);
+      }
+    }
+  }, [authData, showPhotoPermissionRequestPopup, showPhotoPermissionBlockedPopup]);
 
   const requestNewPost = useCallback(async ({ content }) => {
     // console.log('New!');
@@ -140,12 +169,12 @@ export default function NewPostTemplate(): JSX.Element {
 
       if (cameraAuth === 'blocked' || photoAuth === 'blocked') {
         e.preventDefault();
-        return moveToOption();
+        return setShowPhotoPermissionBlockedPopup(true);
       }
 
       if ((cameraAuth === 'empty' || photoAuth === 'empty') || cameraAuth === 'denied' || photoAuth === 'denied') {
         e.preventDefault();
-        return requestMultiPermission({ permissionTypeList: ['CAMERA', 'PHOTO']});
+        return setShowPhotoPermissionRequestPopup(true);
       }
     }
   };
@@ -153,7 +182,8 @@ export default function NewPostTemplate(): JSX.Element {
   return (
     <MainContainer>
       <HeaderSection>
-        <Icon.Back height={'14px'} style={{ cursor: 'pointer', marginBottom: '3px' }} onClick={() => stackRouterBack(router)}/>
+        <Icon.Back height={'14px'} style={{ cursor: 'pointer', marginBottom: '3px' }}
+                   onClick={() => stackRouterBack(router)}/>
         <CloseButton disabled={watchContent.length < 1}
                      onClick={handleSubmit(requestNewPost, onError)}>{'저장'}</CloseButton>
       </HeaderSection>
@@ -213,6 +243,11 @@ export default function NewPostTemplate(): JSX.Element {
           setShowCategory(false);
         }}
       />}
+
+      {showPhotoPermissionRequestPopup &&
+      <PhotoPermissionRequestPopup closeDispatch={() => setShowPhotoPermissionRequestPopup(false)}/>}
+      {showPhotoPermissionBlockedPopup &&
+      <PhotoPermissionBlockedPopup closeDispatch={() => setShowPhotoPermissionBlockedPopup(false)}/>}
     </MainContainer>
   );
 }

--- a/components/templates/NewPostTemplate.tsx
+++ b/components/templates/NewPostTemplate.tsx
@@ -182,8 +182,12 @@ export default function NewPostTemplate(): JSX.Element {
   return (
     <MainContainer>
       <HeaderSection>
-        <Icon.Back height={'14px'} style={{ cursor: 'pointer', marginBottom: '3px' }}
-                   onClick={() => stackRouterBack(router)}/>
+        <div
+          style={{ cursor: 'pointer', marginBottom: '3px', width: '30px', height: '40px', lineHeight: '70px' }}
+          onClick={() => stackRouterBack(router)}
+        >
+          <Icon.Back height={'14px'} />
+        </div>
         <CloseButton disabled={watchContent.length < 1}
                      onClick={handleSubmit(requestNewPost, onError)}>{'저장'}</CloseButton>
       </HeaderSection>

--- a/utils/device.ts
+++ b/utils/device.ts
@@ -10,16 +10,41 @@ export const getBrowser = (): string => {
   return '기타 브라우저';
 };
 
+export const isIphone = () => {
+  let isIphone = false;
+  if (typeof window !== 'undefined') {
+    const userAgent = window.navigator.userAgent.toLowerCase();
+    isIphone = userAgent.match(/iphone\s([0-9.]*)/) !== null;
+  }
+
+  return isIphone;
+};
+
+export const isAndroid = () => {
+  let isAndroid = false;
+  if (typeof window !== 'undefined') {
+    const userAgent = window.navigator.userAgent.toLowerCase();
+    isAndroid = userAgent.match(/android\s([0-9.]*)/) !== null;
+  }
+
+  return isAndroid;
+};
+
 export const getDevice = (): string => {
   if (typeof window !== 'undefined') {
-    const value = window.navigator.userAgent.toLowerCase();
-    let result = value.match(/android\s([0-9.]*)/);
-    if (result !== null) {
-      return 'android';
+    if (isAndroid()) {
+      if (isApp()) {
+        return 'app_android';
+      } else {
+        return 'android';
+      }
     }
-    result = value.match(/iphone\s([0-9.]*)/);
-    if (result !== null) {
-      return 'iphone';
+    if (isIphone()) {
+      if (isApp()) {
+        return 'app_ios';
+      } else {
+        return 'iphone';
+      }
     }
   }
   return 'web';


### PR DESCRIPTION
## What?

app permission 관련 feature 추가

## Why?

고밍아웃에 필요한 관련 권한들을 받기 위해

## How?

- 글쓰기에서 카메라 및 저장공간 permission Popup 추가 (글쓰기 페이지에서 받음)
- IOS에서 APP Permission 받는 Popup 추가 (로그인 인트로 페이지에서 받음)

## Testing?

####  * 테스팅은 머지된 후 앱에서 시도해야함
- 글쓰기에서 사진 첨부 눌렀을 때 관련 팝업 뜨는지 확인
- 관련 팝업에서 설정했을 때 작동이 잘 되는지 확인
- IOS에서 초기페이지 접속시 ATT Permission 받는 팝업 뜨는지 확인(최초 1회만 뜸 + 폰 자체에서 ATT 꺼놓은 경우 안뜸)

## Anything Else?

- 글쓰기 뒤로가기 및 카테고리 선택 영역 조정
- 로그인 페이지 로딩 로직 잘못돼 있어 수정